### PR TITLE
Adding multi command support in a single payload

### DIFF
--- a/pyvyos/device.py
+++ b/pyvyos/device.py
@@ -104,7 +104,28 @@ class VyDevice:
         Returns:
             dict: The payload for the API request.
         """
+        if not path:
+            data = {
+                'op': op,
+                'path': path
+            }
 
+            if file is not None:
+                data['file'] = file
+                
+            if url is not None:
+                data['url'] = url
+            
+            if name is not None:
+                data['name'] = name
+                
+            payload = {
+                'data': json.dumps(data),
+                'key': self.apikey
+            }
+
+            return payload
+            
         if isinstance(path, list) and len(path) == 1:
             # If path is a list and contains only one element, use it directly
             data = {'op': op, 'path': path[0]}

--- a/pyvyos/device.py
+++ b/pyvyos/device.py
@@ -132,11 +132,16 @@ class VyDevice:
             'key': self.apikey
         }
 
+        if file is not None:
+            data['file'] = file
+
         if url is not None:
             payload['url'] = url
 
-        return payload
+        if name is not None:
+            data['name'] = name
 
+        return payload
 
     def _api_request(self, command, op, path=[], method='POST', file=None, url=None, name=None):
         """

--- a/pyvyos/device.py
+++ b/pyvyos/device.py
@@ -125,8 +125,8 @@ class VyDevice:
             }
 
             return payload
-            
-        if isinstance(path, list) and len(path) == 1:
+
+        elif isinstance(path, list) and len(path) == 1:
             # If path is a list and contains only one element, use it directly
             data = {'op': op, 'path': path[0]}
         else:

--- a/pyvyos/device.py
+++ b/pyvyos/device.py
@@ -104,26 +104,39 @@ class VyDevice:
         Returns:
             dict: The payload for the API request.
         """
-        data = {
-            'op': op,
-            'path': path
-        }
+        if isinstance(path, str):
+            path = [path]
 
-        if file is not None:
-            data['file'] = file
-            
-        if url is not None:
-            data['url'] = url
-        
-        if name is not None:
-            data['name'] = name
-            
+        if isinstance(path, list) and len(path) == 1:
+            # If path is a list and contains only one element, use it directly
+            data = {'op': op, 'path': path[0]}
+        else:
+            data = []
+            current_command = {'op': op, 'path': []}
+            for p in path:
+                if isinstance(p, list):
+                    # If the current item is a list, merge it into the current command
+                    if current_command['path']:
+                        data.append(current_command)
+                    current_command = {'op': op, 'path': p}
+                else:
+                    # Otherwise, add the item to the current command's path
+                    current_command['path'].append(p)
+
+            # Add the last command to data
+            if current_command['path']:
+                data.append(current_command)
+
         payload = {
             'data': json.dumps(data),
             'key': self.apikey
         }
 
+        if url is not None:
+            payload['url'] = url
+
         return payload
+
 
     def _api_request(self, command, op, path=[], method='POST', file=None, url=None, name=None):
         """

--- a/pyvyos/device.py
+++ b/pyvyos/device.py
@@ -104,8 +104,6 @@ class VyDevice:
         Returns:
             dict: The payload for the API request.
         """
-        if isinstance(path, str):
-            path = [path]
 
         if isinstance(path, list) and len(path) == 1:
             # If path is a list and contains only one element, use it directly


### PR DESCRIPTION
I have updated `_get_payload` function to address the multi commands in a single payload. Now when you run a the following it will submit all commands. 

Multi command:
`device.configure_set(path=[["interfaces", "ethernet", "eth0", "description", "WAN"], ["interfaces", "ethernet", "eth1", "description", "LAN"]])`

Single commands:
`device.configure_set(path=[["interfaces", "ethernet", "eth0", "description", "WAN"]])`

Note: You'll have to use an extra bracket because of lists within lists.