### PR TITLE
Fixing error message not being returned

### DIFF
--- a/pyvyos/core/rest_client.py
+++ b/pyvyos/core/rest_client.py
@@ -364,11 +364,15 @@ class RestClient(ABC):
             error = f"Invalid response format: {str(exc)}"
             status = resp.status_code if resp is not None and isinstance(resp, Response) else 500
 
-
         except HTTPError as exc:
             response = exc.response
             status = response.status_code if response is not None and isinstance(response, Response) else 500
-            error = f"HTTP Error {status}: {response.text[:200] if response else 'Unknown error'}"
+            try:
+                resp_json = response.json() if response else {}
+                api_error = resp_json.get("error", "")
+                error = f"HTTP Error {status}: {api_error or response.text[:200]}"
+            except (JSONDecodeError, AttributeError):
+                error = f"HTTP Error {status}: Unknown error"
 
         except ValueError as exc:
             error = f"Validation Error: {str(exc)}"


### PR DESCRIPTION
This pull request improves error handling in the `_validate_schema` function within `pyvyos/core/rest_client.py`. The main change is to provide more informative error messages when an `HTTPError` is encountered by attempting to extract the `"error"` field from the response JSON before falling back to the raw response text.

Error handling improvements:

* Enhanced the error message for `HTTPError` exceptions in `_validate_schema` to include the `"error"` field from the response JSON if available, and added a fallback to handle JSON decoding errors gracefully.