### PR TITLE
fix: pytest was declared as runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-05-19
+
+### Fixed
+- `pyproject.toml` declared `pytest>=9.0.3` as a **runtime** dependency.
+  `pip install pyvyos==0.4.0` therefore pulled pytest into every install.
+  Removed; pytest is and was always meant to be a `dev` extra only.
+  Runtime dependencies are now `requests>=2.32.0,<3.0` again — matching
+  what the `0.4.0` CHANGELOG claimed.
+
 ## [0.4.0] - 2025-11-20
 
 `0.4.0` is a cleanup and consolidation release. It is the first version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyvyos"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     { name = "Roberto Berto", email = "463349+robertoberto@users.noreply.github.com" },
 ]
@@ -28,7 +28,6 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "pytest>=9.0.3",
     "requests>=2.32.0,<3.0",
 ]
 


### PR DESCRIPTION
pyproject.toml [project].dependencies declared pytest>=9.0.3, so 'pip install pyvyos==0.4.0' pulled pytest into every install. This contradicted the 0.4.0 CHANGELOG which advertised runtime deps as 'requests>=2.32.0,<3.0 only'.

The line was introduced accidentally during the e2e harness work in bfcaffe (almost certainly an 'uv add pytest' that landed in the wrong table) and was not caught in review.

Removed; pytest remains in the 'dev' optional-dependency extra.

Bump to 0.4.1 to ship the correction to PyPI.