### PR TITLE
docs: cross-reference packer-vyos as related project

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ local Proxmox host and runs `tests/e2e` against the real HTTPS API.
 It is not part of the default GitHub Actions workflow. See the
 harness README for setup.
 
+## Related projects
+
+- [`vyos-contrib/packer-vyos`](https://github.com/vyos-contrib/packer-vyos)
+  — Packer builder that produces ready-to-deploy VyOS images for QEMU,
+  Proxmox, AWS, and other targets. Complementary to `pyvyos`: build the
+  image with `packer-vyos`, then drive it from Python with `pyvyos`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome. Please open an issue first to

--- a/tests/pve/README.md
+++ b/tests/pve/README.md
@@ -75,6 +75,17 @@ tests/pve/ensure-template.sh  # phase 2: cloud-init applies API key,
 The script is a state machine on the VMID, so re-running it from any
 point is safe.
 
+### Alternative: prebuilt images with packer-vyos
+
+If you would rather skip the interactive install entirely, you can
+build a ready-to-clone VyOS image with
+[`vyos-contrib/packer-vyos`](https://github.com/vyos-contrib/packer-vyos)
+and import it on the PVE host instead of running phase 1 here. The
+harness scripts still work — you just point `VYOS_TEMPLATE_VMID` at
+the imported image. This harness keeps the install path because it
+has no extra dependencies; `packer-vyos` is a more capable option if
+you want repeatable image builds.
+
 ## Per-run workflow
 
 ```bash


### PR DESCRIPTION
Adds a small **Related projects** section to the main README pointing to [`vyos-contrib/packer-vyos`](https://github.com/vyos-contrib/packer-vyos), and mentions it in `tests/pve/README.md` as an alternative to the interactive install path in the e2e harness.

The two projects are complementary:

- **packer-vyos** builds the appliance image (Packer / QEMU / Proxmox / AWS).
- **pyvyos** drives the appliance once it is running.

### Why

Neither project mentioned the other. Anyone trying to automate VyOS end-to-end is likely to want both, and the cross-reference makes that obvious.

### Scope

Documentation only. No changes to `pyvyos/`, payloads, public API, tests, CI, or dependencies. Unit suite still **57 passed, 4 skipped**.

### Companion PR

A matching PR on `vyos-contrib/packer-vyos` will point back here, so the cross-reference is bidirectional.